### PR TITLE
Shim for XoopsSystemGui class

### DIFF
--- a/modules/system/themes/redmexico/redmexico.php
+++ b/modules/system/themes/redmexico/redmexico.php
@@ -15,6 +15,26 @@ global $xoopsConfig, $rmc_config;
 //include_once XOOPS_ROOT_PATH.'/modules/rmcommon/admin_loader.php';
 
 if($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disable']){
+
+    /**
+     * XOOPS 2.5.8 changes the definition of XoopsSystemGui::validate() to static, as it is used in
+     * call_user_func(). While that fixes warnings, changing the declaration breaks backward compatibility
+     * and creates errors. This shim declares the method appropriate to the definition in XoopsSystemGui.
+     * 2.5.8 works without warnings, and 2.5.7 and earlier work without error.
+     */
+    $reflectionGui = new ReflectionClass('XoopsSystemGui');
+    if ($reflectionGui->getMethod('validate')->isStatic()) {
+        class XoopsGuiRedmexicoShim extends XoopsSystemGui
+        {
+            public static function validate() { return true; }
+        }
+    } else {
+        class XoopsGuiRedmexicoShim extends XoopsSystemGui
+        {
+            public function validate() { return true; }
+        }
+    }
+
     /**
     * XOOPS CPanel "redmexico" GUI class
     * 
@@ -23,14 +43,14 @@ if($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disable']){
     * @author      BitC3R0       <i.bitcero@gmail.com>
     * @version     1.0
     */
-    class XoopsGuiRedmexico extends  XoopsSystemGui
+    class XoopsGuiRedmexico extends  XoopsGuiRedmexicoShim
     {
 	    function __construct(){
 		    
 	    }
-	    
-	    public function validate(){ return true; }
-	    
+
+	    //public static function validate(){ return true; }
+
 	    public function header(){
 		    global $xoopsConfig, $xoopsUser, $xoopsModule, $xoTheme, $xoopsTpl;
 		    parent::header();


### PR DESCRIPTION
Changes to make XOOPS 2.5.8 work without errors in strict mode required a change in the definition of XoopsSystemGui::validate(). These changes will cause errors with old admin themes. This shim declares the validate() method appropriate to the base class to allow the admin theme to work on both 2.5.8 and older versions.