### PR TITLE
Change name of xoops_module_update function

### DIFF
--- a/rmcommon/modules.php
+++ b/rmcommon/modules.php
@@ -822,7 +822,7 @@ function module_uninstall_now(){
 }
 
 
-function xoops_module_update($dirname){
+function module_update($dirname){
     global $xoopsConfig, $xoopsDB;
 
     $dirname = trim($dirname);
@@ -1247,9 +1247,9 @@ function module_update_now(){
     include_once XOOPS_ROOT_PATH.'/modules/system/admin/modulesadmin/modulesadmin.php';
     
     RMEvents::get()->run_event('rmcommon.updating.module', $module);
-    
-    $module_log = xoops_module_update($mod);
-    
+
+    $module_log = module_update($mod);
+
     $module_log = RMEvents::get()->run_event('rmcommon.module.updated', $module_log, $module_log);
     
     //RMFunctions::create_toolbar();

--- a/rmcommon/updates.php
+++ b/rmcommon/updates.php
@@ -462,7 +462,7 @@ function update_locally(){
         }
 
         include_once XOOPS_ROOT_PATH.'/modules/system/admin/modulesadmin/modulesadmin.php';
-        $log = xoops_module_update( $dir );
+        $log = module_update( $dir );
 
         jsonReturn( __('Module updated locally', 'rmcommon'), 0, array('log' => $log) );
 
@@ -485,7 +485,7 @@ function update_locally(){
 
 }
 
-function xoops_module_update($dirname){
+function module_update($dirname){
     global $xoopsConfig, $xoopsDB;
 
     $dirname = trim($dirname);


### PR DESCRIPTION
XOOPS 2.5.8 now includes a function named xoops_module_update in
htdocs/modules/system/admin/modulesadmin/modulesadmin.php

These changes rename functions in RMCommon that conflict with the new function to 'module_update'.