### PR TITLE
Workaround mysql_real_escape_string

### DIFF
--- a/rmcommon/class/ar/db.class.php
+++ b/rmcommon/class/ar/db.class.php
@@ -275,9 +275,10 @@ class RMDb
      * @return string Escaped string
      */
     public function escape($string){
-
+        if(method_exists($this->database, 'escape')) {
+            return $this->database->escape($string);
+        }
         return mysql_real_escape_string($string);
-
     }
 
     /**

--- a/rmcommon/class/config-item.class.php
+++ b/rmcommon/class/config-item.class.php
@@ -25,7 +25,7 @@ class Rmcommon_Config_Item extends RMObject
 
         if ($name == '' || $mod <= 0 ) return;
 
-        $name = mysql_real_escape_string($name);
+        $name = $this->escape($name);
 
         $sql = "SELECT * FROM $this->_dbtable WHERE `conf_name`='$name' AND `conf_modid`=$mod";
         $result = $this->db->query($sql);

--- a/rmcommon/class/object.php
+++ b/rmcommon/class/object.php
@@ -829,7 +829,7 @@ class RMObject
 		if (get_magic_quotes_gpc())
         	$id = stripslashes($id);
 
-		$id = mysql_real_escape_string($id);
+		$id = $this->escape($id);
 
 		$sql = "SELECT * FROM $this->_dbtable WHERE `$this->primary`='$id'";
 		$result = $this->db->query($sql);
@@ -877,7 +877,7 @@ class RMObject
 		foreach ($values as $k => $v){
 			if (get_magic_quotes_gpc())
         		$v = stripslashes($v);
-			$values[$k] = mysql_real_escape_string($v);
+			$values[$k] = $this->escape($v);
 			$query .= $query=='' ? "`$k`='$v'" : " AND `$k`='$v'";
 		}
 
@@ -964,4 +964,16 @@ class RMObject
 		}
 
 	}
+
+    /**
+     * Escape a string for secure use
+     * @param string String to escape
+     * @return string Escaped string
+     */
+    protected function escape($string){
+        if(method_exists($this->db, 'escape')) {
+            return $this->db->escape($string);
+        }
+        return mysql_real_escape_string($string);
+    }
 }


### PR DESCRIPTION
Since XOOPS 2.5.7, there is an escape() method in the database class. In 2.5.8, all use of mysql_* functions was removed from core, to fix warnings in PHP5, and fatal errors in PHP7. The mysqli extension is now used exclusively.

These changes will use the escape() method if it is available, reverting to mysql_real_escape_string() if needed. This enables testing on XOOPS 2.5.8 with RMC in PHP7.